### PR TITLE
84 | Log to current directory rather than parent

### DIFF
--- a/pgfinder/logs/logs.py
+++ b/pgfinder/logs/logs.py
@@ -10,7 +10,7 @@ import logging
 
 start = datetime.now()
 LOG_CONFIG = logging.basicConfig(
-    filename=str(str(Path().cwd()) + start.strftime("%Y-%m-%d-%H-%M-%S") + ".log"), filemode="w"
+    filename=Path().cwd().stem + f"-{start.strftime('%Y-%m-%d-%H-%M-%S')}.log", filemode="w"
 )
 LOG_FORMATTER = logging.Formatter(
     fmt="[%(asctime)s] [%(levelname)-8s] [%(name)s] %(message)s", datefmt="%a, %d %b %Y %H:%M:%S"


### PR DESCRIPTION
This should allow the notebook to run.

Explanation : I made a mistake when introducing the `pgfinder.logs.logs` module that tried to create a log-file in the parent directory from where the code was being run. This resulted in a permission denied as the standard UNIX users typically do not have permission to write to `home/`. My apologies.