### PR TITLE
Ns rse/86 raw data df attr

### DIFF
--- a/pgfinder.ipynb
+++ b/pgfinder.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "# pgfinder End-to-end Demo\n",
     "\n",
@@ -17,19 +15,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "Import required libraries:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from ipysheet import from_dataframe\n",
@@ -40,10 +34,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "masses_file_name = \"data/masses/e_coli_monomer_masses.csv\"\n",
@@ -53,126 +45,16 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "Read and display monoisotopic mass list (first 10 rows):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:07:00] [INFO    ] [pgfinder] Theoretical masses loaded from      : data/masses/e_coli_monomer_masses.csv\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Structure</th>\n",
-       "      <th>Monoisotopicmass</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>gm|0</td>\n",
-       "      <td>498.2061</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>gm (x2)|0</td>\n",
-       "      <td>976.3860</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>gm (x3)|0</td>\n",
-       "      <td>1454.5659</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>gm (x4)|0</td>\n",
-       "      <td>1932.7458</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>gm (x5)|0</td>\n",
-       "      <td>2410.9257</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>gm (x6)|0</td>\n",
-       "      <td>2889.1056</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>gm (x7)|0</td>\n",
-       "      <td>3367.2855</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>gm-AE|1</td>\n",
-       "      <td>698.2858</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>gm-AEJ|1</td>\n",
-       "      <td>870.3706</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>gm-AEJA|1</td>\n",
-       "      <td>941.4077</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Structure  Monoisotopicmass\n",
-       "0       gm|0          498.2061\n",
-       "1  gm (x2)|0          976.3860\n",
-       "2  gm (x3)|0         1454.5659\n",
-       "3  gm (x4)|0         1932.7458\n",
-       "4  gm (x5)|0         2410.9257\n",
-       "5  gm (x6)|0         2889.1056\n",
-       "6  gm (x7)|0         3367.2855\n",
-       "7    gm-AE|1          698.2858\n",
-       "8   gm-AEJ|1          870.3706\n",
-       "9  gm-AEJA|1          941.4077"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "theo_masses = pgio.theo_masses_reader(masses_file_name)\n",
     "display(from_dataframe(theo_masses.head(10)))"
@@ -180,52 +62,16 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "Read and display ftrs list (first 10 rows):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:09:51] [INFO    ] [pgfinder] Mass spectroscopy file loaded from : data/maxquant_test_data.txt\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/neil/miniconda3/envs/pgfinder/lib/python3.9/site-packages/jupyter_client/session.py:718: UserWarning: Message serialization failed with:\n",
-      "Out of range float values are not JSON compliant\n",
-      "Supporting this message is deprecated in jupyter-client 7, please make sure your message is JSON-compliant\n",
-      "  content = self.pack(content)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b39eb166f0de48248661bb4ee3034e78",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Sheet(cells=(Cell(column_end=0, column_start=0, numeric_format='0[.]0', row_end=9, row_start=0, squeeze_row=Fa…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "raw_data = pgio.ms_file_reader(mq_filepath)\n",
     "display(from_dataframe(raw_data.head(10)))"
@@ -233,182 +79,16 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "Run matching:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:09:54] [INFO    ] [pgfinder] Filtering theoretical masses by observed masses\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:09:57] [INFO    ] [pgfinder] Building custom search file\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:09:57] [INFO    ] [pgfinder] Generating variants\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:09:57] [INFO    ] [pgfinder] Matching\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] Cleaning data\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] Processing 182 Sodium Adducts\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 2695 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6966 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3264 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3264 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3264 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3390 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3390 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3026 has already been removed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] No ^K+ found\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] No ^m found\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mod_test = ['Sodium','Nude', 'DeAc']\n",
     "results = matching.data_analysis(raw_data, theo_masses, 0.5, mod_test, 10)"
@@ -416,210 +96,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "Read and display results (first 10 rows):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dc55eb7d4be94da194ad62bee388e647",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Sheet(cells=(Cell(column_end=0, column_start=0, numeric_format='0[.]0', row_end=9, row_start=0, squeeze_row=Fa…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>ID</th>\n",
-       "      <th>rt</th>\n",
-       "      <th>rt_length</th>\n",
-       "      <th>mwMonoisotopic</th>\n",
-       "      <th>theo_mwMonoisotopic</th>\n",
-       "      <th>inferredStructure</th>\n",
-       "      <th>maxIntensity</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>2816</th>\n",
-       "      <td>2816</td>\n",
-       "      <td>11.380</td>\n",
-       "      <td>35.810</td>\n",
-       "      <td>963.38822</td>\n",
-       "      <td>963.3896</td>\n",
-       "      <td>Na+ gm-AEJA|1</td>\n",
-       "      <td>20043.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2955</th>\n",
-       "      <td>2955</td>\n",
-       "      <td>17.497</td>\n",
-       "      <td>12.875</td>\n",
-       "      <td>963.38796</td>\n",
-       "      <td>963.3896</td>\n",
-       "      <td>Na+ gm-AEJA|1</td>\n",
-       "      <td>6282.6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3626</th>\n",
-       "      <td>3626</td>\n",
-       "      <td>16.502</td>\n",
-       "      <td>14.596</td>\n",
-       "      <td>1154.45430</td>\n",
-       "      <td>1154.4521</td>\n",
-       "      <td>Na+ gm-AEJFD|1</td>\n",
-       "      <td>105260.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8285</th>\n",
-       "      <td>8285</td>\n",
-       "      <td>16.502</td>\n",
-       "      <td>6.129</td>\n",
-       "      <td>1154.46240</td>\n",
-       "      <td>1154.4521</td>\n",
-       "      <td>Na+ gm-AEJFD|1</td>\n",
-       "      <td>7594.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3744</th>\n",
-       "      <td>3744</td>\n",
-       "      <td>19.998</td>\n",
-       "      <td>13.697</td>\n",
-       "      <td>1154.45470</td>\n",
-       "      <td>1154.4521</td>\n",
-       "      <td>Na+ gm-AEJFD|1</td>\n",
-       "      <td>23646.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3711</th>\n",
-       "      <td>3711</td>\n",
-       "      <td>19.103</td>\n",
-       "      <td>9.141</td>\n",
-       "      <td>1191.52950</td>\n",
-       "      <td>1191.5205</td>\n",
-       "      <td>Na+ gm-AEJIW|1</td>\n",
-       "      <td>17434.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8156</th>\n",
-       "      <td>8156</td>\n",
-       "      <td>15.260</td>\n",
-       "      <td>36.380</td>\n",
-       "      <td>991.42483</td>\n",
-       "      <td>991.4252,991.4248</td>\n",
-       "      <td>Na+ gm-AEJV|1,gm-AEJY (Deacetyl) |1</td>\n",
-       "      <td>628180.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2857</th>\n",
-       "      <td>2857</td>\n",
-       "      <td>15.260</td>\n",
-       "      <td>19.878</td>\n",
-       "      <td>991.42425</td>\n",
-       "      <td>991.4252,991.4248</td>\n",
-       "      <td>Na+ gm-AEJV|1,gm-AEJY (Deacetyl) |1</td>\n",
-       "      <td>347940.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3430</th>\n",
-       "      <td>3430</td>\n",
-       "      <td>9.099</td>\n",
-       "      <td>11.976</td>\n",
-       "      <td>1183.51890</td>\n",
-       "      <td>1183.5121,1183.5122</td>\n",
-       "      <td>Na+ gm-AEJYE|1,Na+ gm-AEJYK|1</td>\n",
-       "      <td>396600.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2375</th>\n",
-       "      <td>2375</td>\n",
-       "      <td>4.741</td>\n",
-       "      <td>5.399</td>\n",
-       "      <td>934.37543</td>\n",
-       "      <td>934.3755</td>\n",
-       "      <td>gm (x2) (Deacetyl) |0</td>\n",
-       "      <td>6300.1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "        ID      rt  rt_length  mwMonoisotopic  theo_mwMonoisotopic  \\\n",
-       "2816  2816  11.380     35.810       963.38822             963.3896   \n",
-       "2955  2955  17.497     12.875       963.38796             963.3896   \n",
-       "3626  3626  16.502     14.596      1154.45430            1154.4521   \n",
-       "8285  8285  16.502      6.129      1154.46240            1154.4521   \n",
-       "3744  3744  19.998     13.697      1154.45470            1154.4521   \n",
-       "3711  3711  19.103      9.141      1191.52950            1191.5205   \n",
-       "8156  8156  15.260     36.380       991.42483    991.4252,991.4248   \n",
-       "2857  2857  15.260     19.878       991.42425    991.4252,991.4248   \n",
-       "3430  3430   9.099     11.976      1183.51890  1183.5121,1183.5122   \n",
-       "2375  2375   4.741      5.399       934.37543             934.3755   \n",
-       "\n",
-       "                        inferredStructure  maxIntensity  \n",
-       "2816                        Na+ gm-AEJA|1       20043.0  \n",
-       "2955                        Na+ gm-AEJA|1        6282.6  \n",
-       "3626                       Na+ gm-AEJFD|1      105260.0  \n",
-       "8285                       Na+ gm-AEJFD|1        7594.0  \n",
-       "3744                       Na+ gm-AEJFD|1       23646.0  \n",
-       "3711                       Na+ gm-AEJIW|1       17434.0  \n",
-       "8156  Na+ gm-AEJV|1,gm-AEJY (Deacetyl) |1      628180.0  \n",
-       "2857  Na+ gm-AEJV|1,gm-AEJY (Deacetyl) |1      347940.0  \n",
-       "3430        Na+ gm-AEJYE|1,Na+ gm-AEJYK|1      396600.0  \n",
-       "2375                gm (x2) (Deacetyl) |0        6300.1  "
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "display(from_dataframe(results.head(10)))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "Save output:"
    ]
@@ -627,9 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "results.to_csv(output_file_name)"
@@ -638,20 +131,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "argv": [
-    "python",
-    "-m",
-    "ipykernel_launcher",
-    "-f",
-    "{connection_file}"
-   ],
    "display_name": "Python 3 (ipykernel)",
-   "env": null,
-   "interrupt_mode": "signal",
    "language": "python",
-   "metadata": {
-    "debugger": true
-   },
    "name": "python3"
   },
   "language_info": {
@@ -664,7 +145,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.12"
   },
   "name": "pgfinder.ipynb"
  },

--- a/pgfinder.ipynb
+++ b/pgfinder.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "# pgfinder End-to-end Demo\n",
     "\n",
@@ -15,15 +17,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "Import required libraries:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "from ipysheet import from_dataframe\n",
@@ -34,8 +40,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "masses_file_name = \"data/masses/e_coli_monomer_masses.csv\"\n",
@@ -45,33 +53,179 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "Read and display monoisotopic mass list (first 10 rows):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:07:00] [INFO    ] [pgfinder] Theoretical masses loaded from      : data/masses/e_coli_monomer_masses.csv\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Structure</th>\n",
+       "      <th>Monoisotopicmass</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>gm|0</td>\n",
+       "      <td>498.2061</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>gm (x2)|0</td>\n",
+       "      <td>976.3860</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>gm (x3)|0</td>\n",
+       "      <td>1454.5659</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>gm (x4)|0</td>\n",
+       "      <td>1932.7458</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>gm (x5)|0</td>\n",
+       "      <td>2410.9257</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>gm (x6)|0</td>\n",
+       "      <td>2889.1056</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>gm (x7)|0</td>\n",
+       "      <td>3367.2855</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>gm-AE|1</td>\n",
+       "      <td>698.2858</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>gm-AEJ|1</td>\n",
+       "      <td>870.3706</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>gm-AEJA|1</td>\n",
+       "      <td>941.4077</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Structure  Monoisotopicmass\n",
+       "0       gm|0          498.2061\n",
+       "1  gm (x2)|0          976.3860\n",
+       "2  gm (x3)|0         1454.5659\n",
+       "3  gm (x4)|0         1932.7458\n",
+       "4  gm (x5)|0         2410.9257\n",
+       "5  gm (x6)|0         2889.1056\n",
+       "6  gm (x7)|0         3367.2855\n",
+       "7    gm-AE|1          698.2858\n",
+       "8   gm-AEJ|1          870.3706\n",
+       "9  gm-AEJA|1          941.4077"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "theo_masses = pd.read_csv(masses_file_name)\n",
+    "theo_masses = pgio.theo_masses_reader(masses_file_name)\n",
     "display(from_dataframe(theo_masses.head(10)))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "Read and display ftrs list (first 10 rows):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:09:51] [INFO    ] [pgfinder] Mass spectroscopy file loaded from : data/maxquant_test_data.txt\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/neil/miniconda3/envs/pgfinder/lib/python3.9/site-packages/jupyter_client/session.py:718: UserWarning: Message serialization failed with:\n",
+      "Out of range float values are not JSON compliant\n",
+      "Supporting this message is deprecated in jupyter-client 7, please make sure your message is JSON-compliant\n",
+      "  content = self.pack(content)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b39eb166f0de48248661bb4ee3034e78",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Sheet(cells=(Cell(column_end=0, column_start=0, numeric_format='0[.]0', row_end=9, row_start=0, squeeze_row=Fa…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "raw_data = pgio.ms_file_reader(mq_filepath)\n",
     "display(from_dataframe(raw_data.head(10)))"
@@ -79,16 +233,182 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "Run matching:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:09:54] [INFO    ] [pgfinder] Filtering theoretical masses by observed masses\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:09:57] [INFO    ] [pgfinder] Building custom search file\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:09:57] [INFO    ] [pgfinder] Generating variants\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:09:57] [INFO    ] [pgfinder] Matching\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] Cleaning data\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] Processing 182 Sodium Adducts\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 2695 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6966 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3264 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3264 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3264 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3390 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3390 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 6377 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] drop idx: 3026 has already been removed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] No ^K+ found\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Fri, 27 May 2022 12:10:00] [INFO    ] [pgfinder] No ^m found\n"
+     ]
+    }
+   ],
    "source": [
     "mod_test = ['Sodium','Nude', 'DeAc']\n",
     "results = matching.data_analysis(raw_data, theo_masses, 0.5, mod_test, 10)"
@@ -96,25 +416,210 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "Read and display results (first 10 rows):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
+    "collapsed": false,
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dc55eb7d4be94da194ad62bee388e647",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Sheet(cells=(Cell(column_end=0, column_start=0, numeric_format='0[.]0', row_end=9, row_start=0, squeeze_row=Fa…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>rt</th>\n",
+       "      <th>rt_length</th>\n",
+       "      <th>mwMonoisotopic</th>\n",
+       "      <th>theo_mwMonoisotopic</th>\n",
+       "      <th>inferredStructure</th>\n",
+       "      <th>maxIntensity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2816</th>\n",
+       "      <td>2816</td>\n",
+       "      <td>11.380</td>\n",
+       "      <td>35.810</td>\n",
+       "      <td>963.38822</td>\n",
+       "      <td>963.3896</td>\n",
+       "      <td>Na+ gm-AEJA|1</td>\n",
+       "      <td>20043.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2955</th>\n",
+       "      <td>2955</td>\n",
+       "      <td>17.497</td>\n",
+       "      <td>12.875</td>\n",
+       "      <td>963.38796</td>\n",
+       "      <td>963.3896</td>\n",
+       "      <td>Na+ gm-AEJA|1</td>\n",
+       "      <td>6282.6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3626</th>\n",
+       "      <td>3626</td>\n",
+       "      <td>16.502</td>\n",
+       "      <td>14.596</td>\n",
+       "      <td>1154.45430</td>\n",
+       "      <td>1154.4521</td>\n",
+       "      <td>Na+ gm-AEJFD|1</td>\n",
+       "      <td>105260.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8285</th>\n",
+       "      <td>8285</td>\n",
+       "      <td>16.502</td>\n",
+       "      <td>6.129</td>\n",
+       "      <td>1154.46240</td>\n",
+       "      <td>1154.4521</td>\n",
+       "      <td>Na+ gm-AEJFD|1</td>\n",
+       "      <td>7594.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3744</th>\n",
+       "      <td>3744</td>\n",
+       "      <td>19.998</td>\n",
+       "      <td>13.697</td>\n",
+       "      <td>1154.45470</td>\n",
+       "      <td>1154.4521</td>\n",
+       "      <td>Na+ gm-AEJFD|1</td>\n",
+       "      <td>23646.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3711</th>\n",
+       "      <td>3711</td>\n",
+       "      <td>19.103</td>\n",
+       "      <td>9.141</td>\n",
+       "      <td>1191.52950</td>\n",
+       "      <td>1191.5205</td>\n",
+       "      <td>Na+ gm-AEJIW|1</td>\n",
+       "      <td>17434.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8156</th>\n",
+       "      <td>8156</td>\n",
+       "      <td>15.260</td>\n",
+       "      <td>36.380</td>\n",
+       "      <td>991.42483</td>\n",
+       "      <td>991.4252,991.4248</td>\n",
+       "      <td>Na+ gm-AEJV|1,gm-AEJY (Deacetyl) |1</td>\n",
+       "      <td>628180.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2857</th>\n",
+       "      <td>2857</td>\n",
+       "      <td>15.260</td>\n",
+       "      <td>19.878</td>\n",
+       "      <td>991.42425</td>\n",
+       "      <td>991.4252,991.4248</td>\n",
+       "      <td>Na+ gm-AEJV|1,gm-AEJY (Deacetyl) |1</td>\n",
+       "      <td>347940.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3430</th>\n",
+       "      <td>3430</td>\n",
+       "      <td>9.099</td>\n",
+       "      <td>11.976</td>\n",
+       "      <td>1183.51890</td>\n",
+       "      <td>1183.5121,1183.5122</td>\n",
+       "      <td>Na+ gm-AEJYE|1,Na+ gm-AEJYK|1</td>\n",
+       "      <td>396600.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2375</th>\n",
+       "      <td>2375</td>\n",
+       "      <td>4.741</td>\n",
+       "      <td>5.399</td>\n",
+       "      <td>934.37543</td>\n",
+       "      <td>934.3755</td>\n",
+       "      <td>gm (x2) (Deacetyl) |0</td>\n",
+       "      <td>6300.1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        ID      rt  rt_length  mwMonoisotopic  theo_mwMonoisotopic  \\\n",
+       "2816  2816  11.380     35.810       963.38822             963.3896   \n",
+       "2955  2955  17.497     12.875       963.38796             963.3896   \n",
+       "3626  3626  16.502     14.596      1154.45430            1154.4521   \n",
+       "8285  8285  16.502      6.129      1154.46240            1154.4521   \n",
+       "3744  3744  19.998     13.697      1154.45470            1154.4521   \n",
+       "3711  3711  19.103      9.141      1191.52950            1191.5205   \n",
+       "8156  8156  15.260     36.380       991.42483    991.4252,991.4248   \n",
+       "2857  2857  15.260     19.878       991.42425    991.4252,991.4248   \n",
+       "3430  3430   9.099     11.976      1183.51890  1183.5121,1183.5122   \n",
+       "2375  2375   4.741      5.399       934.37543             934.3755   \n",
+       "\n",
+       "                        inferredStructure  maxIntensity  \n",
+       "2816                        Na+ gm-AEJA|1       20043.0  \n",
+       "2955                        Na+ gm-AEJA|1        6282.6  \n",
+       "3626                       Na+ gm-AEJFD|1      105260.0  \n",
+       "8285                       Na+ gm-AEJFD|1        7594.0  \n",
+       "3744                       Na+ gm-AEJFD|1       23646.0  \n",
+       "3711                       Na+ gm-AEJIW|1       17434.0  \n",
+       "8156  Na+ gm-AEJV|1,gm-AEJY (Deacetyl) |1      628180.0  \n",
+       "2857  Na+ gm-AEJV|1,gm-AEJY (Deacetyl) |1      347940.0  \n",
+       "3430        Na+ gm-AEJYE|1,Na+ gm-AEJYK|1      396600.0  \n",
+       "2375                gm (x2) (Deacetyl) |0        6300.1  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "display(from_dataframe(results.head(10)))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "Save output:"
    ]
@@ -122,7 +627,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "results.to_csv(output_file_name)"
@@ -131,8 +638,20 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "argv": [
+    "python",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}"
+   ],
+   "display_name": "Python 3 (ipykernel)",
+   "env": null,
+   "interrupt_mode": "signal",
    "language": "python",
+   "metadata": {
+    "debugger": true
+   },
    "name": "python3"
   },
   "language_info": {
@@ -146,7 +665,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.8"
-  }
+  },
+  "name": "pgfinder.ipynb"
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/pgfinder/pgio.py
+++ b/pgfinder/pgio.py
@@ -127,22 +127,23 @@ def ftrs_reader(file: Union[str, Path]) -> pd.DataFrame:
         return ff
 
 
-def theo_masses_reader(file: Union[str, Path]) -> pd.DataFrame:
+def theo_masses_reader(input_file: Union[str, Path]) -> pd.DataFrame:
     """Reads theoretical masses files (csv)
 
     Parameters
     ----------
-    file: Union[str, Path]
+    input_file: Union[str, Path]
 
     Returns
     -------
         Pandas DataFrame of theoretical masses.
     """
     # reads csv files and converts to dataframe
-    theo_masses_df = pd.read_csv(file)
+    theo_masses_df = pd.read_csv(input_file)
 
-    theo_masses_df.attrs["file"] = file
-    LOGGER.info(f"Theoretical masses loaded from      : {file}")
+    print(f"##### input_file : {}")
+    theo_masses_df.attrs["file"] = input_file
+    LOGGER.info(f"Theoretical masses loaded from      : {input_file}")
     return theo_masses_df
 
 

--- a/pgfinder/pgio.py
+++ b/pgfinder/pgio.py
@@ -141,7 +141,6 @@ def theo_masses_reader(input_file: Union[str, Path]) -> pd.DataFrame:
     # reads csv files and converts to dataframe
     theo_masses_df = pd.read_csv(input_file)
 
-    print(f"##### input_file : {}")
     theo_masses_df.attrs["file"] = input_file
     LOGGER.info(f"Theoretical masses loaded from      : {input_file}")
     return theo_masses_df


### PR DESCRIPTION
Resolves #86 

For some reason the theoretical masses data frame was being read with `pd.read_csv()`. This meant that the `theo_masses` Pandas DataFrame passed to `matching.data_analysis()` to do the matching had no attribute `"file"`. The solution was to switch to using `pgio.theo_masses_reader()` to load the `theo_masses` DataFrame in the first place as it is this function that sets the attributes on the object.

At the same time I have modified the `pgio.theo_masses_reader()` argument to be `input_file` rather than the keyword `file` to avoid possible problems.