### PR TITLE
Ns rse/93 fix ghpages

### DIFF
--- a/.github/workflows/sphinx_docx_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docx_to_gh_pages.yaml
@@ -4,7 +4,7 @@ name: Sphinx docs to gh-pages
 on:
   push:
     branches:
-      - master
+      - ns-rse/93-fix-ghpages
 
 # workflow_dispatch:        # Un comment line if you also want to trigger action manually
 
@@ -26,7 +26,7 @@ jobs:
       - name: Running Sphinx to gh-pages Action
         uses: ns-rse/action-sphinx-docs-to-gh-pages@main
         with:
-          branch: master
+          branch: ns-rse/93-fix-ghpages
           dir_docs: docs
           sphinxapiexclude: '../*setup* ../*tests* ../*.ipynb ../demo.py ../make_baseline.py ../jupyter_notebook_config.py ../demo_ftrs.py'
           sphinxapiopts: '--separate -o . ../'

--- a/.github/workflows/sphinx_docx_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docx_to_gh_pages.yaml
@@ -4,7 +4,7 @@ name: Sphinx docs to gh-pages
 on:
   push:
     branches:
-      - ns-rse/93-fix-ghpages
+      - master
 
 # workflow_dispatch:        # Un comment line if you also want to trigger action manually
 
@@ -26,7 +26,7 @@ jobs:
       - name: Running Sphinx to gh-pages Action
         uses: ns-rse/action-sphinx-docs-to-gh-pages@main
         with:
-          branch: ns-rse/93-fix-ghpages
+          branch: master
           dir_docs: docs
           sphinxapiexclude: '../*setup* ../*tests* ../*.ipynb ../demo.py ../make_baseline.py ../jupyter_notebook_config.py ../demo_ftrs.py'
           sphinxapiopts: '--separate -o . ../'

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ tests =
 docs =
   sphinx<5.0
   myst_parser
-  pydata_sphinx_theme
+  pydata_sphinx_theme==0.8.1
   sphinx_markdown_tables
   sphinx_rtd_theme
   sphinxcontrib-mermaid


### PR DESCRIPTION
Resolves #93 

An update to the theme package [`pydata-sphinx-theme-0.9.0`](https://github.com/pydata/pydata-sphinx-theme/) causes a fatal error on building the documentation (see [#710](https://github.com/pydata/pydata-sphinx-theme/issues/710)). For now the version required/installed is pegged to `0.8.1`, the documentation builds and deploys again and in future should only do so when changes are merged into `master`.