### PR TITLE
120 | Patched version of sphinx-markdown-tables

### DIFF
--- a/.github/workflows/sphinx_docx_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docx_to_gh_pages.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Installing the Documentation requirements
         run: |
           pip3 install .[docs]
+          pip install git+https://github.com/Dzordzu/sphinx-markdown-tables.git@markdown-patch
       - name: Running Sphinx to gh-pages Action
         uses: ns-rse/action-sphinx-docs-to-gh-pages@main
         with:


### PR DESCRIPTION
GitHub pages are currently not available because of a bug in sphinx-markdown-tables (see #120 for details).

This installs a patched version of `sphinx-markdown-tables` prior to building the documentation and should hopefully restore the pages. :crossed_fingers: 