### PR TITLE
120 | Order matters, install patched sphinx-markdown-tables 1st

### DIFF
--- a/.github/workflows/sphinx_docx_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docx_to_gh_pages.yaml
@@ -22,8 +22,8 @@ jobs:
           python-version: 3.9
       - name: Installing the Documentation requirements
         run: |
+          pip3 install git+https://github.com/Dzordzu/sphinx-markdown-tables.git@markdown-patch
           pip3 install .[docs]
-          pip install git+https://github.com/Dzordzu/sphinx-markdown-tables.git@markdown-patch
       - name: Running Sphinx to gh-pages Action
         uses: ns-rse/action-sphinx-docs-to-gh-pages@main
         with:


### PR DESCRIPTION
Resolves #120 

Order matters, needed to install the patched `sphinx-markdown-tables` first before its pulled in and installed by the extra requirements defined in `setup.cfg`.