### PR TITLE
120 | sphinx-markdown-tables-0.0.16 released, reverting

### DIFF
--- a/.github/workflows/sphinx_docx_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docx_to_gh_pages.yaml
@@ -22,7 +22,6 @@ jobs:
           python-version: 3.9
       - name: Installing the Documentation requirements
         run: |
-          pip3 install git+https://github.com/Dzordzu/sphinx-markdown-tables.git@markdown-patch
           pip3 install .[docs]
       - name: Running Sphinx to gh-pages Action
         uses: ns-rse/action-sphinx-docs-to-gh-pages@main


### PR DESCRIPTION
The [sphinx-markdown-tables issue 36](https://github.com/ryanfox/sphinx-markdown-tables/issues/36) which caused the documentation to fail building has now been fixed and a new version released. Reverting the changes to the pipeline.