### PR TITLE
131 | Correcting PyPI and GH Pages workflows to work on tagged commit…

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -2,8 +2,8 @@ name: Publish package to PyPi
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - v*
 
 jobs:
   build-release:
@@ -19,13 +19,13 @@ jobs:
           python-version: 3.9
       - name: Installing the package
         run: |
+          pip3 install versioneer
           pip3 install .
           pip3 install .[pypi]
       - name: Build package
         run: |
           python -m build --no-isolation
       - name: Publish package to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -3,8 +3,8 @@ name: Sphinx docs to gh-pages
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - v*
 
 # workflow_dispatch:        # Un comment line if you also want to trigger action manually
 


### PR DESCRIPTION
Closes #131 

The two workflows modified in this commit will only run on commits which are tagged with the form `v*` (where * can be anything but typically is a semantic version number).