### PR TITLE
fix(deps): remove unneeded matplotlib dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # Mock imports (things that can't be installed at do building time)
 
-autodoc_mock_imports = ["numpy", "pandas", "matplotlib", "scipy"]
+autodoc_mock_imports = ["numpy", "pandas", "pyyaml"]
 
 # -- Project information -----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ keywords = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "matplotlib",
   "numpy",
   "pandas",
   "pyyaml"


### PR DESCRIPTION
One for @bobturneruk and @ns-rse to have a quick glance at!

I don't think we're using `matplotlib` anywhere, so I feel pretty safe getting rid of it, but I'm not 100% sure if I should be changing those documentation "mock imports" like I have!