### PR TITLE
refactor(naming)!: add glycosidic bonds back into mass libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.3] - 2023-08-28
+
+### Changed
+
+- Nude glycan chains in the built-in mass libraries now contain `-` (#210)
+
 ## [1.0.0-rc.2] - 2023-08-28
 
 ### Changed
@@ -18,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Let there be peptidoglycan.
 
-[Unreleased]: https://github.com/Mesnage-Org/pgfinder/compare/v1.0.0-rc.2...HEAD
+[Unreleased]: https://github.com/Mesnage-Org/pgfinder/compare/v1.0.0-rc.3...HEAD
+[1.0.0-rc.3]: https://github.com/Mesnage-Org/pgfinder/compare/v1.0.0-rc.2...v1.0.0-rc.3
 [1.0.0-rc.2]: https://github.com/Mesnage-Org/pgfinder/compare/v1.0.0-rc.1...v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/Mesnage-Org/pgfinder/releases/tag/v1.0.0-rc.1

--- a/pgfinder/masses/c_diff_monomers_complex.csv
+++ b/pgfinder/masses/c_diff_monomers_complex.csv
@@ -1,10 +1,10 @@
 Structure,Monoisotopicmass
 g(-Ac)m|0,456.195525
-g(-Ac)mgm|0,934.375400
-g(-Ac)mg(-Ac)m|0,892.364835
-g(-Ac)mgmgm|0,1412.555275
-g(-Ac)mg(-Ac)mgm|0,1370.544710
-g(-Ac)mg(-Ac)mg(-Ac)m|0,1328.534145
+g(-Ac)m-gm|0,934.375400
+g(-Ac)m-g(-Ac)m|0,892.364835
+g(-Ac)m-gm-gm|0,1412.555275
+g(-Ac)m-g(-Ac)m-gm|0,1370.544710
+g(-Ac)m-g(-Ac)m-g(-Ac)m|0,1328.534145
 g(-Ac)m-A|1,527.232639
 g(-Ac)m-AE|1,656.275232
 g(-Ac)m-AEJ|1,828.360024

--- a/pgfinder/masses/c_diff_monomers_non_redundant.csv
+++ b/pgfinder/masses/c_diff_monomers_non_redundant.csv
@@ -1,10 +1,10 @@
 Structure,Monoisotopicmass
 g(-Ac)m|0,456.195525
-g(-Ac)mgm|0,934.375400
-g(-Ac)mg(-Ac)m|0,892.364835
-g(-Ac)mgmgm|0,1412.555275
-g(-Ac)mg(-Ac)mgm|0,1370.544710
-g(-Ac)mg(-Ac)mg(-Ac)m|0,1328.534145
+g(-Ac)m-gm|0,934.375400
+g(-Ac)m-g(-Ac)m|0,892.364835
+g(-Ac)m-gm-gm|0,1412.555275
+g(-Ac)m-g(-Ac)m-gm|0,1370.544710
+g(-Ac)m-g(-Ac)m-g(-Ac)m|0,1328.534145
 g(-Ac)m-A|1,527.232639
 g(-Ac)m-AE|1,656.275232
 g(-Ac)m-AEJ|1,828.360024

--- a/pgfinder/masses/c_diff_monomers_simple.csv
+++ b/pgfinder/masses/c_diff_monomers_simple.csv
@@ -1,10 +1,10 @@
 Structure,Monoisotopicmass
 g(-Ac)m|0,456.195525
-g(-Ac)mgm|0,934.375400
-g(-Ac)mg(-Ac)m|0,892.364835
-g(-Ac)mgmgm|0,1412.555275
-g(-Ac)mg(-Ac)mgm|0,1370.544710
-g(-Ac)mg(-Ac)mg(-Ac)m|0,1328.534145
+g(-Ac)m-gm|0,934.375400
+g(-Ac)m-g(-Ac)m|0,892.364835
+g(-Ac)m-gm-gm|0,1412.555275
+g(-Ac)m-g(-Ac)m-gm|0,1370.544710
+g(-Ac)m-g(-Ac)m-g(-Ac)m|0,1328.534145
 g(-Ac)m-A|1,527.232639
 g(-Ac)m-AE|1,656.275232
 g(-Ac)m-AEJ|1,828.360024

--- a/pgfinder/masses/e_coli_monomers_complex.csv
+++ b/pgfinder/masses/e_coli_monomers_complex.csv
@@ -1,7 +1,7 @@
 Structure,Monoisotopicmass
 gm|0,498.206090
-gmgm|0,976.385965
-gmgmgm|0,1454.565840
+gm-gm|0,976.385965
+gm-gm-gm|0,1454.565840
 gm-A|1,569.243204
 gm-AE|1,698.285797
 gm-AEJ|1,870.370589

--- a/pgfinder/masses/e_coli_monomers_non_redundant.csv
+++ b/pgfinder/masses/e_coli_monomers_non_redundant.csv
@@ -1,7 +1,7 @@
 Structure,Monoisotopicmass
 gm|0,498.206090
-gmgm|0,976.385965
-gmgmgm|0,1454.565840
+gm-gm|0,976.385965
+gm-gm-gm|0,1454.565840
 gm-A|1,569.243204
 gm-AE|1,698.285797
 gm-AEJ|1,870.370589

--- a/pgfinder/masses/e_coli_monomers_simple.csv
+++ b/pgfinder/masses/e_coli_monomers_simple.csv
@@ -1,7 +1,7 @@
 Structure,Monoisotopicmass
 gm|0,498.206090
-gmgm|0,976.385965
-gmgmgm|0,1454.565840
+gm-gm|0,976.385965
+gm-gm-gm|0,1454.565840
 gm-A|1,569.243204
 gm-AE|1,698.285797
 gm-AEJ|1,870.370589


### PR DESCRIPTION
This brings things back in line with the `-` for glycosidic multimers standard