### PR TITLE
Recursively autosummary of API docs

### DIFF
--- a/lib/docs/api.rst
+++ b/lib/docs/api.rst
@@ -2,6 +2,7 @@ API
 ===
 
 .. autosummary::
+   :recursive:
    :toctree: generated
 
    pgfinder


### PR DESCRIPTION
Closes #239

Not the problem I thought but this appears to fix it when building locally.

![image](https://github.com/Mesnage-Org/pgfinder/assets/17566406/406a21fc-33cc-426b-b0b4-8a00f5605b32)

![image](https://github.com/Mesnage-Org/pgfinder/assets/17566406/212a67fd-d583-4743-a69e-9e81aa7ffc16)

:crossed_fingers: it carries through to ReadTheDocs. :crossed_fingers: 