### PR TITLE
Switching to & configuring autoapi.extension for build docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,6 +23,3 @@ python:
       path: lib/
       extra_requirements:
         - docs
-        - sphinx.ext.autodoc
-        - sphinx_autodoc_typehints
-        - sphinx.ext.autosummary

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,3 +23,6 @@ python:
       path: lib/
       extra_requirements:
         - docs
+        - sphinx.ext.autodoc
+        - sphinx_autodoc_typehints
+        - sphinx.ext.autosummary

--- a/lib/docs/conf.py
+++ b/lib/docs/conf.py
@@ -9,6 +9,7 @@
 # -- Path setup --------------------------------------------------------------
 
 import os
+from pathlib import Path
 import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -44,6 +45,7 @@ version = ".".join(release.split(".")[:2])
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "autoapi.extension",
     "sphinx.ext.autodoc",
     "sphinx_autodoc_typehints",
     "sphinx.ext.viewcode",
@@ -86,6 +88,13 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "setup.py"]
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
 
+# -- autoapi configuration ---------------------------------------------------
+
+# Language of source code to parse
+autoapi_type = "python"
+
+# Source code to parse to generate API docs relative to 'docs/source' directory
+autoapi_dirs = [Path("../pgfinder/")]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/lib/docs/conf.py
+++ b/lib/docs/conf.py
@@ -9,7 +9,6 @@
 # -- Path setup --------------------------------------------------------------
 
 import os
-from pathlib import Path
 import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -17,6 +16,7 @@ import sys
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 from importlib.metadata import version
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(".."))
 


### PR DESCRIPTION
In order to get the API documentation to build on ReadTheDocs.org this PR switches to using the `autoapi.extension`.

Tested and builds on this branch see for example [here](https://pgfinder.readthedocs.io/en/ns-rse-239-api-docs/autoapi/pgfinder/errors/index.html#pgfinder.errors.UserError).