### PR TITLE
Remove sphinx.ext.autosummary from lib/docs/conf.py

### DIFF
--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -32,7 +32,7 @@ jobs:
         run: pnpm install
 
       - name: Install Playwright Browsers & Dependencies
-        run: playwright install --with-deps
+        run: pnpx playwright install --with-deps
 
       - name: Run Playwright Tests
-        run: pnpm test
+        run: pnpx playwright test

--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -32,7 +32,7 @@ jobs:
         run: pnpm install
 
       - name: Install Playwright Browsers & Dependencies
-        run: pnpx playwright install --with-deps
+        run: playwright install --with-deps
 
       - name: Run Playwright Tests
         run: pnpm test

--- a/.github/workflows/e2e-checks.yml
+++ b/.github/workflows/e2e-checks.yml
@@ -32,7 +32,7 @@ jobs:
         run: pnpm install
 
       - name: Install Playwright Browsers & Dependencies
-        run: pnpx playwright install --with-deps
+        run: pnpm exec playwright install --with-deps
 
       - name: Run Playwright Tests
-        run: pnpx playwright test
+        run: pnpm test

--- a/lib/docs/api.rst
+++ b/lib/docs/api.rst
@@ -1,8 +1,0 @@
-API
-===
-
-.. autosummary::
-   :recursive:
-   :toctree: generated
-
-   pgfinder

--- a/lib/docs/conf.py
+++ b/lib/docs/conf.py
@@ -52,7 +52,6 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
-    "sphinx.ext.autosummary",
     "sphinx_rtd_theme",
     "myst_parser",
     "numpydoc",

--- a/lib/docs/index.rst
+++ b/lib/docs/index.rst
@@ -16,7 +16,6 @@ Welcome to pgfinder's documentation!
    :maxdepth: 2
    :caption: API
 
-   api
 
 Indices and tables
 ==================


### PR DESCRIPTION
Hopefully this closes #239 and the API duplication will no longer occur.