### PR TITLE
Fixing pytest-regtest issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
       - id: fix-byte-order-marker
       - id: name-tests-test
         args: ["--pytest-test-first"]
+      - id: no-commit-to-branch # Protects main/master by default
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
@@ -32,7 +33,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.1.9"
+    rev: "v0.1.11"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -48,7 +49,7 @@ repos:
   #         - svelte
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.56.0
+    rev: v9.0.0-alpha.0
     hooks:
       - id: eslint
         types: [file]

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -40,7 +40,7 @@ tests = [
   "pytest>=7.0",
   "pytest-cov",
   "pytest-mpl",
-  "pytest-regtest",
+  "pytest-regtest<2.0.0",
   "pytest-xdist"
 ]
 docs = [
@@ -134,6 +134,10 @@ target-version = "py38"
 select = ["B", "E", "F", "W", "I001"]
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F", "R", "S", "W", "U", "I001"]
+
+[tool.ruff.lint]
+extend-select = ["NPY201"]
+preview = true
 
 [project.scripts]
 find_pg = "pgfinder.find_pg:main"


### PR DESCRIPTION
New releases of `pytest-regtest>=2.0.0` on PyPI are currently broken as the released packages don't appear to include the Python code for the module itself. This has been reported upstream and when fixed I will remove the dependency.

+ [pytest-regtest #20](https://gitlab.com/uweschmitt/pytest-regtest/-/issues/20)

At the same time I've...

+ Made the `pre-commit` updates that were automated in #253 where the `pytest-regtest` issue cropped up
+ Added `no-commit-to-branch` check to `pre-commit` hooks which protects against commits to `master` locally.
+ Introduced `NPY201` checks under `ruff` linting to check for forthcoming Numpy2 deprecations.

Numpy2 is due to be released early later this year (first release candidate is scheduled 2024-02-01).

This may introduce some breaking changes, a broad overview is available [here](https://pythonspeed.com/articles/numpy-2/).

Mentioned in that article is that `scikit-image` has issues, which is indirect because the package has an optional dependency on `matplotlib` (I've discovered this whilst working on `skan` issues).

The official [NumPy 2.0 migration guide — NumPy v2.0.dev0 Manual](https://numpy.org/devdocs/numpy_2_0_migration_guide.html) suggests that `ruff` can be leveraged to address the mentioned changes under [Ruff Plugin](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ruff-plugin).

A useful summary of how to handle potential problems is provided at [Numpy #24300](numpy/numpy#24300) and broadly suggests pinning `numpy<2.0` for releases whilst development proceeds on resolving issues.