### PR TITLE
Unpeg pytest-regtest

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -40,7 +40,7 @@ tests = [
   "pytest>=7.0",
   "pytest-cov",
   "pytest-mpl",
-  "pytest-regtest<2.0.0",
+  "pytest-regtest",
   "pytest-xdist"
 ]
 docs = [


### PR DESCRIPTION
Upstream problem appears to have been resolved so unpegging to test CI.