### PR TITLE
chore: Updates action versions

### DIFF
--- a/.github/workflows/lib-tests.yml
+++ b/.github/workflows/lib-tests.yml
@@ -17,9 +17,9 @@ jobs:
       run:
         working-directory: ./lib
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
         run: |
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
       - name: Checking CLI entry-point works
         run: |
           pip install -e .


### PR DESCRIPTION
`lib-tests` were showing warnings about outdated Node.js actions...

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-python@v2, codecov/codecov-action@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

This PR updates the following steps.

+ `actions/checkout@v2` > `actions/checkout@v4`
+ `actions/setup-python@v2` > `actions/setup-python@v5`
+ `codecov/codecov-action@v2` > `codecov/codecov-action@v4`